### PR TITLE
namespace clase8 agregado

### DIFF
--- a/clase-8/03.2-mariadb-service.yaml
+++ b/clase-8/03.2-mariadb-service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: mariadb
   labels:
     app: clase8
+  namespace: clase8
 spec:
   ports:
     - port: 3306


### PR DESCRIPTION
Agrego "namepespace: clase8" en metadata dado que en kind, wordpress no encontraba a mariadb y tira error en base de datos. Al hacer un "kubectl get svc -n clase8" solo aparecía wordpress, con esa modificación todo funciona correctamente.