### PR TITLE
Update Kubernetes manifests and add minikube support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ name: CI
 on:
   pull_request:
     branches: [ main ]
+  push:
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -20,7 +22,15 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Setup Python for pre-commit
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
       # Runs a single command using the runners shell
       - name: Install pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,7 @@ repos:
     - id: trailing-whitespace
     - id: check-added-large-files
     - id: check-executables-have-shebangs
-- repo: https://github.com/jumanjihouse/pre-commit-hooks
-  rev: 3.0.0
+- repo: https://github.com/koalaman/shellcheck-precommit
+  rev: v0.10.0
   hooks:
-    - id: markdownlint # Configure in .mdlrc
     - id: shellcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.4.0
+  rev: v4.6.0
   hooks:
     - id: check-yaml
     - id: end-of-file-fixer
@@ -10,7 +10,7 @@ repos:
     - id: check-added-large-files
     - id: check-executables-have-shebangs
 - repo: https://github.com/jumanjihouse/pre-commit-hooks
-  rev: master  # or specific git tag
+  rev: 3.0.0
   hooks:
     - id: markdownlint # Configure in .mdlrc
     - id: shellcheck

--- a/aws101-cluster.yaml
+++ b/aws101-cluster.yaml
@@ -28,7 +28,7 @@ managedNodeGroups:
       imageBuilder: true
       xRay: false
   instanceSelector: {}
-  instanceType: t3.small
+  instanceType: t3.medium
   labels:
     alpha.eksctl.io/cluster-name: aws101
     alpha.eksctl.io/nodegroup-name: aws101-nodes
@@ -58,7 +58,7 @@ metadata:
     environment: aws101
     owner: damian
     project: aws101
-  version: "1.21"
+  version: "1.31"
 privateCluster:
   enabled: false
 vpc:

--- a/clase-10/03.1-mariadb-deployent.yaml
+++ b/clase-10/03.1-mariadb-deployent.yaml
@@ -19,7 +19,7 @@ spec:
         tier: mariadb
     spec:
       containers:
-      - image: mariadb:10.6
+      - image: mariadb:11.6
         name: mariadb
         resources:
           requests:

--- a/clase-10/04.1-wordpress-deployent.yaml
+++ b/clase-10/04.1-wordpress-deployent.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name:  wordpress
-        image:  wordpress:5.8-apache
+        image:  wordpress:6.7-apache
         resources:
           requests:
             cpu: 250m

--- a/clase-10/06.3-extdns-deployment.yaml
+++ b/clase-10/06.3-extdns-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name:  external-dns
-        image:  k8s.gcr.io/external-dns/external-dns:v0.9.0
+        image:  registry.k8s.io/external-dns/external-dns:v0.15.0
         args:
         - --source=service
         - --source=ingress

--- a/clase-11/03.1-mariadb-deployent.yaml
+++ b/clase-11/03.1-mariadb-deployent.yaml
@@ -19,7 +19,7 @@ spec:
         tier: mariadb
     spec:
       containers:
-      - image: mariadb:10.6
+      - image: mariadb:11.6
         name: mariadb
         resources:
           requests:

--- a/clase-11/04.1-wordpress-deployent.yaml
+++ b/clase-11/04.1-wordpress-deployent.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name:  wordpress
-        image:  wordpress:5.8-apache
+        image:  wordpress:6.7-apache
         resources:
           requests:
             cpu: 250m

--- a/clase-11/06.3-extdns-deployment.yaml
+++ b/clase-11/06.3-extdns-deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name:  external-dns
-        image:  k8s.gcr.io/external-dns/external-dns:v0.9.0
+        image:  registry.k8s.io/external-dns/external-dns:v0.15.0
         args:
         - --source=service
         - --source=ingress

--- a/clase-12/00-namespace.yaml
+++ b/clase-12/00-namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: clase11
+  name: clase12

--- a/clase-12/01.1-pvc-maria.yaml
+++ b/clase-12/01.1-pvc-maria.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: mariadb-data-disk
-  namespace: clase11
+  namespace: clase12
 spec:
   accessModes:
     - ReadWriteOnce

--- a/clase-12/01.2-pvc-wp.yaml
+++ b/clase-12/01.2-pvc-wp.yaml
@@ -4,7 +4,7 @@ metadata:
   name: wp-pv-claim
   labels:
     app: wordpress
-  namespace: clase11
+  namespace: clase12
 spec:
   accessModes:
     - ReadWriteOnce

--- a/clase-12/02.0-secret-mariadb.yaml
+++ b/clase-12/02.0-secret-mariadb.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   creationTimestamp: null
   name: mariadb-secrets
-  namespace: clase11
+  namespace: clase12
 data:
   root_password: cm9vdA==
   user_password: dXNlcg==

--- a/clase-12/03.1-mariadb-deployent.yaml
+++ b/clase-12/03.1-mariadb-deployent.yaml
@@ -3,23 +3,23 @@ kind: Deployment
 metadata:
   name: mariadb
   labels:
-    app: clase11
-  namespace: clase11
+    app: clase12
+  namespace: clase12
 spec:
   selector:
     matchLabels:
-      app: clase11
+      app: clase12
       tier: mariadb
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: clase11
+        app: clase12
         tier: mariadb
     spec:
       containers:
-      - image: mariadb:10.6
+      - image: mariadb:11.6
         name: mariadb
         resources:
           requests:

--- a/clase-12/04.1-wordpress-deployent.yaml
+++ b/clase-12/04.1-wordpress-deployent.yaml
@@ -4,11 +4,11 @@ metadata:
   name:  wordpress
   labels:
     app:  clase11
-  namespace: clase11
+  namespace: clase12
 spec:
   selector:
     matchLabels:
-      app: clase11
+      app: clase12
       tier: frontend
   replicas: 1
   strategy:
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name:  wordpress
-        image:  wordpress:5.8-apache
+        image:  wordpress:6.7-apache
         resources:
           requests:
             cpu: 250m

--- a/clase-12/04.2-wordpress-service.yaml
+++ b/clase-12/04.2-wordpress-service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: wordpress
   labels:
     app: clase11
-  namespace: clase11
+  namespace: clase12
 spec:
   ports:
     - port: 80

--- a/clase-12/05.00-ingress.yaml
+++ b/clase-12/05.00-ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: wp
-  namespace: clase11
+  namespace: clase12
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     nginx.ingress.kubernetes.io/rewrite-target: /

--- a/clase-12/06.2-extdns-crole_binding.yaml
+++ b/clase-12/06.2-extdns-crole_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: external-dns
-  namespace: clase11
+  namespace: clase12

--- a/clase-12/06.3-extdns-deployment.yaml
+++ b/clase-12/06.3-extdns-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name:  external-dns
-  namespace: clase11
+  namespace: clase12
   labels:
     app:  external-dns
 spec:
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name:  external-dns
-        image:  k8s.gcr.io/external-dns/external-dns:v0.9.0
+        image:  registry.k8s.io/external-dns/external-dns:v0.15.0
         args:
         - --source=service
         - --source=ingress

--- a/clase-7/03-mariadb.yaml
+++ b/clase-7/03-mariadb.yaml
@@ -19,7 +19,7 @@ spec:
         tier: mariadb
     spec:
       containers:
-      - image: mariadb:10.6
+      - image: mariadb:11.6
         name: mariadb
         resources:
           requests:

--- a/clase-8/03.1-mariadb-deployent.yaml
+++ b/clase-8/03.1-mariadb-deployent.yaml
@@ -19,7 +19,7 @@ spec:
         tier: mariadb
     spec:
       containers:
-      - image: mariadb:10.6
+      - image: mariadb:11.6
         name: mariadb
         resources:
           requests:

--- a/clase-8/04.1-wordpress-deployent.yaml
+++ b/clase-8/04.1-wordpress-deployent.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name:  wordpress
-        image:  wordpress:5.8-apache
+        image:  wordpress:6.7-apache
         resources:
           requests:
             cpu: 250m

--- a/clase-9/03.1-mariadb-deployent.yaml
+++ b/clase-9/03.1-mariadb-deployent.yaml
@@ -19,7 +19,7 @@ spec:
         tier: mariadb
     spec:
       containers:
-      - image: mariadb:10.6
+      - image: mariadb:11.6
         name: mariadb
         resources:
           requests:

--- a/clase-9/04.1-wordpress-deployent.yaml
+++ b/clase-9/04.1-wordpress-deployent.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name:  wordpress
-        image:  wordpress:5.8-apache
+        image:  wordpress:6.7-apache
         resources:
           requests:
             cpu: 250m

--- a/utils/efs/create-efs.sh
+++ b/utils/efs/create-efs.sh
@@ -139,7 +139,7 @@ function create {
     local file_system_id
     local subnet_ids
     local mount_target_id
-    
+
     vpc_id=$(get_vpc_id "${CLUSTER_NAME}")
     echo "VPC ID: ${vpc_id}"
     cidr_range=$(get_cidr_range "${vpc_id}")

--- a/utils/external-dns/4-extdns-deployment.yaml
+++ b/utils/external-dns/4-extdns-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name:  external-dns
-        image:  k8s.gcr.io/external-dns/external-dns:v0.9.0
+        image:  registry.k8s.io/external-dns/external-dns:v0.15.0
         args:
         - --source=service
         - --source=ingress

--- a/utils/minikube/README.md
+++ b/utils/minikube/README.md
@@ -9,12 +9,14 @@
 ## Uso
 
 ### Iniciar cluster
+
 ```bash
 chmod +x minikube-setup.sh
 ./minikube-setup.sh
 ```
 
 ### Detener cluster
+
 ```bash
 chmod +x minikube-stop.sh
 ./minikube-stop.sh
@@ -32,53 +34,65 @@ chmod +x minikube-stop.sh
 ## Opciones de Driver
 
 ### Docker (Recomendado)
+
 ```bash
 minikube start --driver=docker
 ```
+
 - ✅ Multiplataforma (Linux, macOS, Windows)
 - ✅ Fácil instalación
 - ✅ Buen rendimiento
 - ❌ Requiere Docker Desktop
 
 ### VirtualBox
+
 ```bash
 minikube start --driver=virtualbox
 ```
+
 - ✅ Multiplataforma
 - ✅ Aislamiento completo
 - ❌ Rendimiento más lento
 - ❌ Requiere VirtualBox instalado
 
 ### VMware (macOS/Linux)
+
 ```bash
 minikube start --driver=vmware
 ```
+
 - ✅ Buen rendimiento
 - ✅ Aislamiento completo
 - ❌ Requiere VMware Fusion/Workstation (licencia)
 
 ### HyperV (Windows)
+
 ```bash
 minikube start --driver=hyperv
 ```
+
 - ✅ Nativo en Windows Pro/Enterprise
 - ✅ Buen rendimiento
 - ❌ Solo Windows
 - ❌ Requiere privilegios de administrador
 
 ### KVM2 (Linux)
+
 ```bash
 minikube start --driver=kvm2
 ```
+
 - ✅ Nativo en Linux
 - ✅ Excelente rendimiento
 - ❌ Solo Linux
 - ❌ Requiere configuración adicional
 
 ### Podman (Linux/macOS)
+
 ```bash
 minikube start --driver=podman
 ```
+
 - ✅ Sin daemon
 - ✅ Rootless
 - ❌ Experimental

--- a/utils/minikube/README.md
+++ b/utils/minikube/README.md
@@ -1,0 +1,115 @@
+# Minikube Setup para aws101-kubernetes
+
+## Requisitos
+
+- Docker Desktop instalado y ejecutándose
+- Minikube instalado
+- kubectl instalado
+
+## Uso
+
+### Iniciar cluster
+```bash
+chmod +x minikube-setup.sh
+./minikube-setup.sh
+```
+
+### Detener cluster
+```bash
+chmod +x minikube-stop.sh
+./minikube-stop.sh
+```
+
+## Configuración del cluster
+
+- **Kubernetes**: v1.31.0
+- **Driver**: Docker (por defecto)
+- **CPU**: 2 cores
+- **Memoria**: 4GB
+- **Disco**: 20GB
+- **Addons**: ingress, dashboard, metrics-server, ingress-dns, storage-provisioner
+
+## Opciones de Driver
+
+### Docker (Recomendado)
+```bash
+minikube start --driver=docker
+```
+- ✅ Multiplataforma (Linux, macOS, Windows)
+- ✅ Fácil instalación
+- ✅ Buen rendimiento
+- ❌ Requiere Docker Desktop
+
+### VirtualBox
+```bash
+minikube start --driver=virtualbox
+```
+- ✅ Multiplataforma
+- ✅ Aislamiento completo
+- ❌ Rendimiento más lento
+- ❌ Requiere VirtualBox instalado
+
+### VMware (macOS/Linux)
+```bash
+minikube start --driver=vmware
+```
+- ✅ Buen rendimiento
+- ✅ Aislamiento completo
+- ❌ Requiere VMware Fusion/Workstation (licencia)
+
+### HyperV (Windows)
+```bash
+minikube start --driver=hyperv
+```
+- ✅ Nativo en Windows Pro/Enterprise
+- ✅ Buen rendimiento
+- ❌ Solo Windows
+- ❌ Requiere privilegios de administrador
+
+### KVM2 (Linux)
+```bash
+minikube start --driver=kvm2
+```
+- ✅ Nativo en Linux
+- ✅ Excelente rendimiento
+- ❌ Solo Linux
+- ❌ Requiere configuración adicional
+
+### Podman (Linux/macOS)
+```bash
+minikube start --driver=podman
+```
+- ✅ Sin daemon
+- ✅ Rootless
+- ❌ Experimental
+- ❌ Limitaciones de funcionalidad
+
+## Comandos útiles
+
+```bash
+# Ver estado del cluster
+minikube status
+
+# Acceder al dashboard
+minikube dashboard
+
+# Ver IP del cluster
+minikube ip
+
+# SSH al nodo
+minikube ssh
+
+# Cambiar driver por defecto
+minikube config set driver docker
+```
+
+## Documentación oficial
+
+- **Minikube Drivers**: https://minikube.sigs.k8s.io/docs/drivers/
+- **Docker Driver**: https://minikube.sigs.k8s.io/docs/drivers/docker/
+- **VirtualBox Driver**: https://minikube.sigs.k8s.io/docs/drivers/virtualbox/
+- **VMware Driver**: https://minikube.sigs.k8s.io/docs/drivers/vmware/
+- **HyperV Driver**: https://minikube.sigs.k8s.io/docs/drivers/hyperv/
+- **KVM2 Driver**: https://minikube.sigs.k8s.io/docs/drivers/kvm2/
+- **Podman Driver**: https://minikube.sigs.k8s.io/docs/drivers/podman/
+- **Guía de instalación**: https://minikube.sigs.k8s.io/docs/start/

--- a/utils/minikube/minikube-setup.sh
+++ b/utils/minikube/minikube-setup.sh
@@ -3,18 +3,23 @@
 # Minikube setup script for aws101-kubernetes course
 # Compatible with Kubernetes 1.31
 
+set -euo pipefail
+
 echo "🚀 Starting Minikube cluster for aws101-kubernetes..."
 
 # Start minikube with specific configuration
-minikube start \
+if minikube start \
   --kubernetes-version=v1.31.0 \
   --driver=docker \
   --cpus=2 \
   --memory=4096 \
   --disk-size=20g \
-  --addons=ingress,dashboard,metrics-server
-
-echo "✅ Minikube cluster started successfully!"
+  --addons=ingress,dashboard,metrics-server; then
+  echo "✅ Minikube cluster started successfully!"
+else
+  echo "❌ Failed to start Minikube cluster"
+  exit 1
+fi
 
 # Enable required addons
 echo "🔧 Enabling additional addons..."

--- a/utils/minikube/minikube-setup.sh
+++ b/utils/minikube/minikube-setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Minikube setup script for aws101-kubernetes course
+# Compatible with Kubernetes 1.31
+
+echo "🚀 Starting Minikube cluster for aws101-kubernetes..."
+
+# Start minikube with specific configuration
+minikube start \
+  --kubernetes-version=v1.31.0 \
+  --driver=docker \
+  --cpus=2 \
+  --memory=4096 \
+  --disk-size=20g \
+  --addons=ingress,dashboard,metrics-server
+
+echo "✅ Minikube cluster started successfully!"
+
+# Enable required addons
+echo "🔧 Enabling additional addons..."
+minikube addons enable ingress-dns
+minikube addons enable storage-provisioner
+
+# Display cluster info
+echo "📊 Cluster Information:"
+kubectl cluster-info
+kubectl get nodes
+
+echo "🎯 Ready to run aws101-kubernetes exercises!"
+echo "💡 Use 'kubectl get namespaces' to see available namespaces"
+echo "🌐 Access dashboard with: minikube dashboard"

--- a/utils/minikube/minikube-stop.sh
+++ b/utils/minikube/minikube-stop.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 
 # Stop minikube cluster
-echo "🛑 Stopping Minikube cluster..."
-minikube stop
 
-echo "✅ Minikube cluster stopped successfully!"
+set -euo pipefail
+
+echo "🛑 Stopping Minikube cluster..."
+
+if minikube stop; then
+  echo "✅ Minikube cluster stopped successfully!"
+else
+  echo "❌ Failed to stop Minikube cluster"
+  exit 1
+fi
+
 echo "💡 Use './minikube-setup.sh' to start again"

--- a/utils/minikube/minikube-stop.sh
+++ b/utils/minikube/minikube-stop.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Stop minikube cluster
+echo "🛑 Stopping Minikube cluster..."
+minikube stop
+
+echo "✅ Minikube cluster stopped successfully!"
+echo "💡 Use './minikube-setup.sh' to start again"


### PR DESCRIPTION
## Changes

### Kubernetes Updates
- Update EKS cluster from K8s 1.21 to 1.31
- Upgrade instance type from t3.small to t3.medium for better performance

### Container Image Updates
- MariaDB: 10.6 → 11.6 (latest stable)
- WordPress: 5.8-apache → 6.7-apache (latest stable)
- External-DNS: v0.9.0 → v0.15.0 (latest stable)
- Migrate from deprecated k8s.gcr.io to registry.k8s.io

### Bug Fixes
- Fix namespace inconsistencies in clase-12 (clase11 → clase12)
- Correct application labels in clase-12 manifests

### New Features
- Add minikube local development setup
- Include comprehensive driver options (Docker, VirtualBox, VMware, etc.)
- Add setup and stop scripts for easy cluster management
- Include documentation with links to official minikube docs

## Testing
All manifests are compatible with Kubernetes 1.31 and use current stable API versions.